### PR TITLE
tests: adapt client's resolv.conf for test environment

### DIFF
--- a/ipatests/test_integration/test_forced_client_reenrollment.py
+++ b/ipatests/test_integration/test_forced_client_reenrollment.py
@@ -270,7 +270,8 @@ class TestForcedClientReenrollment(IntegrationTest):
         contents = self.master.get_file_contents(self.BACKUP_KEYTAB)
         self.clients[0].put_file_contents(self.BACKUP_KEYTAB, contents)
 
-    def fix_resolv_conf(self, client, server):
+    @classmethod
+    def fix_resolv_conf(cls, client, server):
         """
         Put server's ip address at the top of resolv.conf
         """
@@ -281,9 +282,9 @@ class TestForcedClientReenrollment(IntegrationTest):
             contents = nameserver + contents.replace(nameserver, '')
             client.put_file_contents(paths.RESOLV_CONF, contents)
 
-
 @pytest.fixture()
 def client(request):
+    request.cls.fix_resolv_conf(request.cls.clients[0], request.cls.master)
     tasks.install_client(request.cls.master, request.cls.clients[0])
 
     def teardown_client():


### PR DESCRIPTION
In some test environments client's resolv.conf may point to upstream
dns server and we do not get dns records from client to master then.

Fix is for test_forced_client_reenrollment test suite.

https://pagure.io/freeipa/issue/7124